### PR TITLE
Add CORS for Vite development server

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, Flask, jsonify, render_template
+from flask_cors import CORS
 import sqlite3
 from swagger_ui import api_doc
 
@@ -52,8 +53,11 @@ def get_dynamic_page(*_):
 def init_app(app: Flask):
     # 負責靜態資源
     app.register_blueprint(bp_web_page)
+
     # 負責處理 API 請求
+    CORS(bp_web_api, origins=['http://localhost:5173'])
     app.register_blueprint(bp_web_api)
+
     # Generate Web API documentation
     api_doc(
         app,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
+flask-cors
 swagger-ui-py


### PR DESCRIPTION
# Add CORS for Vite development server

## Description

As the title says.

For more details, take a look at these screenshots of `http://127.0.0.1:5173` on Safari browser:

| Branch | Screenshot |
|--------|------------|
| main   | ![](https://github.com/Basketball-Competition-Dashboard/Project/assets/37398747/82139bf5-9240-42b0-a986-464d1776c061) |
| cors   | ![](https://github.com/Basketball-Competition-Dashboard/Project/assets/37398747/25f39373-54a4-416d-9eac-69d10e14b491) |

Besides, I updated the sub-module `web`.

## Motivation or Context

For the frontend development, I runs the main server (`127.0.0.1:5000`) and Vite development server (`127.0.0.1:5173`) at the same time.

I need this CORS setting to ease the frontend team development.

## Checklist

| Item          | Is checked? | Description                                        |
| ------------- | ----------- | -------------------------------------------------- |
| Explanation   | O           | My changes are well-explained.                     |
| Documentation | O           | My works are well-commented or clear.              |
| Tests         | O           | I have added tests or reports to cover my changes. |
