### PR TITLE
Fix the database path and add the instructions for Web E2E Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@
 1. Try to update all dependencies by following the [installation steps](#installation) if you have encountered any issue.
 2. The site URL is [http://127.0.0.1:5000](http://127.0.0.1:5000)
 3. The Web API documentation URL is [http://127.0.0.1:5000/_doc/api/web](http://127.0.0.1:5000/_doc/api/web)
+4. The Web E2E tests are run by the following command:
+
+    ```shell
+    cd web/
+    bun run test-e2e
+    ```

--- a/app/dataProcess_player_profiles.py
+++ b/app/dataProcess_player_profiles.py
@@ -1,8 +1,11 @@
 import sqlite3
 import random
+
+DATABASE_PATH = f'{__file__}/../../data/nbaDB.db'
+
 def fetch_player_profiles(length, offset, sort_field, sort_order):
     try:
-      conn = sqlite3.connect('data/nbaDB.db')
+      conn = sqlite3.connect(DATABASE_PATH)
       cursor = conn.cursor()
         # 構建排序字段和順序
       sort_column = 'FName || " " || LName' if sort_field == 'name' else 'BDate'

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,6 +4,8 @@ import uuid
 from swagger_ui import api_doc
 from app import dataProcess_player_profiles
 
+DATABASE_PATH = f'{__file__}/../../data/nbaDB.db'
+
 # __name__ == app.routes
 # __name__取得當前模組的名稱，用於定位相對路徑
 bp_web_api = Blueprint(
@@ -33,10 +35,10 @@ def login():
         data = request.get_json()
         name = data['name']
         credential = data['credential']
-    except KeyError:
+    except:
         return jsonify({"message": "Your request is invalid."}), 400
 
-    conn = sqlite3.connect('data/nbaDB.db')
+    conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
     cursor.execute(
         'SELECT Account, Password FROM Manager where Account = ? and Password = ? limit 1;',
@@ -80,7 +82,7 @@ def get_games():
     sort_field = sort.get('field', 'date')
     sort_order = sort.get('order', 'ascending')
 
-    conn = sqlite3.connect('data/nbaDB.db')
+    conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
     
     sort_order_sql = 'ASC' if sort_order == 'ascending' else 'DESC'
@@ -186,7 +188,7 @@ def put_games():
     # if not request_data:
     #     return make_response(jsonify({'message': 'Your request is invalid.'}), 400)
     
-    # conn = sqlite3.connect('data/nbaDB.db')
+    # conn = sqlite3.connect(DATABASE_PATH)
     # cursor = conn.cursor()
     
     # for game in request_data:


### PR DESCRIPTION
# Fix the database path and add the instructions for Web E2E Tests

## Description

As the title says.

Besides, you can run Web E2E tests by running the command `bun run test-e2e` or NPM equivalent in the `web` submodule.

## Motivation or Context

- Fix the database path
  - More robust settings. Specifically, it fixed errors during Web E2E tests.
- Add the instructions for Web E2E Tests
  - E2E tests would be useful for checking basic concepts.

## Checklist

| Item          | Is checked? | Description                                        |
| ------------- | ----------- | -------------------------------------------------- |
| Explanation   | O           | My changes are well-explained.                     |
| Documentation | O           | My works are well-commented or clear.              |
| Tests         | O           | I have added tests or reports to cover my changes. |
