### PR TITLE
CORS for Vite development server

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, Flask, jsonify, render_template, request, Response,make_response
+from flask_cors import CORS
 import sqlite3
 import uuid
 from swagger_ui import api_doc
@@ -436,5 +437,7 @@ def init_app(app: Flask):
         title='Web API Documentation',
         editor=True,
     )
+    # Enable CORS
+    CORS(app, resources={r"/api/web/*": {"origins": "http://localhost:5173"}})
 
     app.logger.info(' * Web API Documentation URL: http://127.0.0.1:5000/_doc/api/web')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask
+flask-cors
+pip
 swagger-ui-py


### PR DESCRIPTION
# CORS for Vite development server

## Description

To allow frontend developer fetch Web API to the site hosted by Vite development server.

The origin of Vite development server is `http://localhost:5173`

## Motivation or Context

To accelerate development

## Checklist

| Item          | Is checked? | Description                                        |
| ------------- | ----------- | -------------------------------------------------- |
| Explanation   | O           | My changes are well-explained.                     |
| Documentation | O           | My works are well-commented or clear.              |
| Tests         | O           | I have added tests or reports to cover my changes. |
