### PR TITLE
Sync origin URL with API spec

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -436,4 +436,4 @@ def init_app(app: Flask):
     # Enable CORS
     CORS(app, resources={r"/api/web/*": {"origins": "http://localhost:5173"}})
 
-    app.logger.info(' * Web API Documentation URL: http://127.0.0.1:5000/_doc/api/web')
+    app.logger.info(' * Web API Documentation URL: http://localhost:5000/_doc/api/web')

--- a/main.py
+++ b/main.py
@@ -5,4 +5,4 @@ from sys import stderr
 if __name__ == '__main__':
     basicConfig(format='%(message)s', level=DEBUG, stream=stderr)
     app = create_app()
-    app.run(host='127.0.0.1', port=5000, debug=True)
+    app.run(host='localhost', port=5000, debug=True)


### PR DESCRIPTION
# Sync origin URL with API spec

## Description

As the title says.

## Motivation or Context

To follow the simpler address in Web API Spec, which is about comparing `127.0.0.1` between `localhost` *(simpler)*, I made the change.

## Checklist

| Item          | Is checked? | Description                                        |
| ------------- | ----------- | -------------------------------------------------- |
| Explanation   | O           | My changes are well-explained.                     |
| Documentation | O           | My works are well-commented or clear.              |
| Tests         | O           | I have added tests or reports to cover my changes. |
