### PR TITLE
revise name in dataProcess_player_stats.py to fname, lname

### DIFF
--- a/app/dataProcess_player_stats.py
+++ b/app/dataProcess_player_stats.py
@@ -85,7 +85,7 @@ def create_player_stats(name, game_date, game_home_abbr, game_away_abbr, assist,
         cursor = conn.cursor()
 
         # print(name)
-        lname, fname = name.split()
+        fname, lname = name.split()
         # print(lname, fname)
 
         cursor.execute("SELECT PID FROM Player WHERE Fname = ? AND Lname = ?", (fname, lname))


### PR DESCRIPTION
## Description

As title says, I found a bug of creating player_stats in dataProcess_player_stats.py.
when spliting name, it should be fname and lname.

